### PR TITLE
feat: add Reverse method to String type

### DIFF
--- a/reverse.go
+++ b/reverse.go
@@ -1,0 +1,8 @@
+package stringx
+
+func (s String) Reverse() (result String) {
+	for i := len(s) - 1; i >= 0; i-- {
+		result = result.Concat(String(s[i]))
+	}
+	return
+}

--- a/reverse_test.go
+++ b/reverse_test.go
@@ -1,0 +1,22 @@
+package stringx
+
+import (
+	"testing"
+
+	"github.com/i9si-sistemas/assert"
+)
+
+func TestReverse(t *testing.T) {
+	s := String("2014-06-08")
+	splitedValues := s.Split(Dash.String())
+	var reversed String
+	for i := len(splitedValues) - 1; i >= 0; i-- {
+		n := splitedValues[i]
+		if i == 0 {
+			reversed = reversed.Concat(String(n).Reverse().Reverse())
+			break
+		}
+		reversed = reversed.Concat(String(n).Reverse().Reverse(), Dash)
+	}
+	assert.Equal(t, reversed.String(), "08-06-2014")
+}


### PR DESCRIPTION
This PR introduces the `Reverse` method to the `String` type. This method reverses the string represented by the `String` object and returns a new `String` object containing the reversed string. It iterates over the string from the last character to the first, concatenating each character to build the reversed string.