### PR TITLE
feat: add ReverseFn method to String type

### DIFF
--- a/reverse.go
+++ b/reverse.go
@@ -6,3 +6,12 @@ func (s String) Reverse() (result String) {
 	}
 	return
 }
+
+type ReverseFn func(index int) String
+
+func (s String) ReverseFn(fn ReverseFn) (result String) {
+	for i := len(s) - 1; i >= 0; i-- {
+		result = result.Concat(fn(i))
+	}
+	return
+}

--- a/reverse_test.go
+++ b/reverse_test.go
@@ -19,4 +19,11 @@ func TestReverse(t *testing.T) {
 		reversed = reversed.Concat(String(n).Reverse().Reverse(), Dash)
 	}
 	assert.Equal(t, reversed.String(), "08-06-2014")
+	s = String("Hello World")
+	assert.Equal(t, s.ReverseFn(func(i int) String {
+		if Space.Equal(string(s[i])) {
+			return Dash
+		}
+		return String(string(s[i]))
+	}), "dlroW-olleH")
 }


### PR DESCRIPTION
This PR introduces the `ReverseFn` method to the `String` type. This method allows reversing a string by applying a function to each character's index during the reversal process. It iterates over the string from the last character to the first, applying the provided function to each index and concatenating the results to build the reversed string.