### PR TITLE
fix: replace panics with fail function in stringx package 

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -53,11 +53,11 @@ func (b *Builder) grow() {
 }
 
 // Grow grows b's capacity, if necessary, to guarantee space for
-// another n bytes. After Grow(n), at least n bytes can be written to b
-// without another allocation. If n is negative, Grow panics.
+// another n bytes.
 func (b *Builder) Grow(n int) {
 	if n < 0 {
-		panic("stringx.Builder.Grow: negative count")
+		fail("stringx.Builder.Grow: negative count", Empty, Log)
+		return
 	}
 	if cap(b.buf)-len(b.buf) < n {
 		b.grow()

--- a/panic.go
+++ b/panic.go
@@ -1,0 +1,11 @@
+package stringx
+
+import "log"
+
+// Log is default printer for stringx.
+var Log = log.Println
+
+func fail(message string, s String, printer func(v ...any)) String {
+	printer(message)
+	return s
+}

--- a/panic_test.go
+++ b/panic_test.go
@@ -1,0 +1,17 @@
+package stringx
+
+import (
+	"log"
+	"testing"
+
+	"github.com/i9si-sistemas/assert"
+)
+
+func TestFail(t *testing.T) {
+	failedMessage := "index out of range"
+	result := String("Hello World")
+	assert.Equal(t, Log, log.Println)
+	fail(failedMessage, result, func(v ...any) {
+		assert.Equal(t, failedMessage, v[0])
+	})
+}

--- a/repeat.go
+++ b/repeat.go
@@ -54,12 +54,12 @@ func repeat(value string, count int) String {
 		return String(value)
 	}
 	if count < 0 {
-		panic("stringx: negative Repeat count")
+		return fail("stringx: negative Repeat count", String(value), Log)
 	}
 	concatLength := len(value) * count
 	hi, lo := bits.Mul(uint(len(value)), uint(count))
 	if hi > 0 || lo > uint(maxInt) {
-		panic("stringx: Repeat output length overflow")
+		return fail("stringx: Repeat output length overflow", String(value), Log)
 	}
 	n := int(lo)
 

--- a/strings.go
+++ b/strings.go
@@ -29,13 +29,13 @@ func (s Strings) Join(sep string) String {
 	var n int
 	if len(sep) > 0 {
 		if len(sep) >= maxInt/(len(s)-1) {
-			panic("stringx: Join output length overflow")
+			return fail("stringx: Join output length overflow", Empty, Log)
 		}
 		n += len(sep) * (len(s) - 1)
 	}
 	for _, elem := range s {
 		if len(elem) > maxInt-n {
-			panic("stringx: Join output length overflow")
+			return fail("stringx: Join output length overflow", Empty, Log)
 		}
 		n += len(elem)
 	}


### PR DESCRIPTION
The `fail` function allows for custom error logging and prevents abrupt program termination.