### PR TITLE
Support comma as decimal separator

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -123,6 +123,10 @@ func (p *Parser) Int() (n int64, err error) {
 func (p *Parser) Float() (n float64, err error) {
 	s := p.s
 	parseFloat := func(s string) (float64, error) {
+		old := ","
+		if New(s).Includes(old) {
+			s = New(s).Replace(old, ".").String()
+		}
 		return strconv.ParseFloat(s, p.bitSize)
 	}
 	ops := []mathOp[float64]{

--- a/parser_test.go
+++ b/parser_test.go
@@ -49,9 +49,9 @@ func TestParser(t *testing.T) {
 	})
 
 	t.Run("Floats", func(t *testing.T) {
-		assert.Equal(t, mustFloat("10.0"), 10.0)
+		assert.Equal(t, mustFloat("10,0"), 10.0)
 		assert.Equal(t, mustFloat("10 + 10.0"), 20.0)
-		assert.Equal(t, mustFloat("10.0 * 20.0"), 200.0)
+		assert.Equal(t, mustFloat("10,0 * 20.0"), 200.0)
 		assert.Equal(t, mustFloat("10.0 - 20.0"), -10.0)
 		assert.Equal(t, mustFloat("10.0 / 20"), 0.5)
 		assert.Equal(t, mustFloat("10 % 20"), 10)


### PR DESCRIPTION
Replaces commas (",") with dots (".") before parsing floats to ensure correct numeric conversion for inputs or locales that use commas as decimal separators.